### PR TITLE
fix(contracts): enforce one-time witness to initialization (Closes #6)

### DIFF
--- a/sui_raffler/sources/sui_raffler.move
+++ b/sui_raffler/sources/sui_raffler.move
@@ -26,6 +26,10 @@ module sui_raffler::sui_raffler {
     use sui::clock::{Self, Clock};
     use sui::event;
     use std::string::{String};
+    use sui::types;
+
+    // OTW - One time witness
+    public struct SUI_RAFFLER has drop {}
 
     // === Constants ===
     // Prize distribution percentages (must sum to 100)
@@ -54,6 +58,7 @@ module sui_raffler::sui_raffler {
     const ERafflePaused: u64 = 15;           // Raffle is paused
     const ENotAuthorized: u64 = 17;          // Not authorized for this operation
     const ENotMinimumTickets: u64 = 18;      // Not enough tickets sold for raffle release
+    const ENotOneTimeWitness: u64 = 19;      // Not one time witness
 
     /// Module configuration that holds admin, controller, fee collector, pause, and permissionless info
     public struct Config has key {
@@ -133,7 +138,8 @@ module sui_raffler::sui_raffler {
 
     /// Initialize the module with admin, controller, and fee collector addresses
     /// This function can only be called once during module deployment
-    public entry fun initialize(admin: address, controller: address, fee_collector: address, ctx: &mut TxContext) {
+    fun initialize(otw: SUI_RAFFLER, admin: address, controller: address, fee_collector: address, ctx: &mut TxContext) {
+        assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
         let config = Config {
             id: object::new(ctx),
             admin,
@@ -650,6 +656,12 @@ module sui_raffler::sui_raffler {
     public fun get_config_fee_collector(config: &Config): address {
         config.fee_collector
     }
+    
+    #[test_only]
+    public fun init_for_testing(admin: address, controller: address, fee_collector: address, ctx: &mut TxContext){
+        initialize(SUI_RAFFLER {}, admin, controller, fee_collector, ctx);
+    }
+
 }
 
 

--- a/sui_raffler/tests/sui_raffler_return_tests.move
+++ b/sui_raffler/tests/sui_raffler_return_tests.move
@@ -44,7 +44,7 @@ fun setup_raffle_with_two_tickets(
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 

--- a/sui_raffler/tests/sui_raffler_security_tests.move
+++ b/sui_raffler/tests/sui_raffler_security_tests.move
@@ -27,7 +27,7 @@ fun test_update_admin_unauthorized() {
     let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -50,7 +50,7 @@ fun test_update_controller_unauthorized() {
     let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -73,7 +73,7 @@ fun test_update_fee_collector_unauthorized() {
     let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -95,7 +95,7 @@ fun test_pause_unauthorized() {
     let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -118,7 +118,7 @@ fun test_pause_raffle_unauthorized() {
     let organizer = @0x1234;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -173,7 +173,7 @@ fun test_release_raffle_unauthorized() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -235,7 +235,7 @@ fun test_claim_organizer_share_unauthorized() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -306,7 +306,7 @@ fun test_claim_prize_unauthorized() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -378,7 +378,7 @@ fun test_cannot_buy_tickets_when_paused() {
     let buyer = @0xB0B;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -426,7 +426,7 @@ fun test_cannot_create_raffle_when_contract_paused() {
     let organizer = @0x1234;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -464,7 +464,7 @@ fun test_create_raffle_not_permissionless() {
     let organizer = @0x1234;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -502,7 +502,7 @@ fun test_buy_tickets_before_start() {
     let buyer = @0xB0B;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -547,7 +547,7 @@ fun test_buy_tickets_after_end() {
     let buyer = @0xB0B;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -606,7 +606,7 @@ fun test_release_raffle_before_end() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -664,7 +664,7 @@ fun test_release_raffle_twice() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -733,7 +733,7 @@ fun test_claim_organizer_share_twice() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -808,7 +808,7 @@ fun test_log_winning_tickets() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -900,7 +900,7 @@ fun test_prize_claiming() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 

--- a/sui_raffler/tests/sui_raffler_tests.move
+++ b/sui_raffler/tests/sui_raffler_tests.move
@@ -9,6 +9,7 @@ use sui::random::{Self, Random};
 use sui::sui::SUI;
 use std::debug;
 use std::string;
+use sui_raffler::sui_raffler::ENotOneTimeWitness;
 
 /// Helper function to mint SUI coins for testing
 fun mint(addr: address, amount: u64, scenario: &mut ts::Scenario) {
@@ -50,7 +51,7 @@ fun test_raffle_flow() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
     assert!(sui_raffler::get_config_fee_collector(&config) == fee_collector, 1);
@@ -187,7 +188,7 @@ fun test_fee_collector_update() {
     let mut ts = ts::begin(admin);
 
     // Initialize module configuration
-    sui_raffler::initialize(admin, controller, initial_fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, initial_fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
     assert!(sui_raffler::get_config_fee_collector(&config) == initial_fee_collector, 1);
@@ -214,7 +215,7 @@ fun test_fee_collector_update_unauthorized() {
     let mut ts = ts::begin(admin);
 
     // Initialize module configuration
-    sui_raffler::initialize(admin, controller, initial_fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, initial_fee_collector, ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -240,7 +241,7 @@ fun test_invalid_organizer() {
     let mut ts = ts::begin(admin);
 
     // Initialize module configuration
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -295,7 +296,7 @@ fun test_happy_path_raffle() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
     assert!(sui_raffler::get_config_fee_collector(&config) == fee_collector, 1);
@@ -591,7 +592,7 @@ fun test_protocol_fee_auto_collection() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::initialize(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -654,3 +655,16 @@ fun test_protocol_fee_auto_collection() {
     ts::return_shared(random_state);
     ts.end();
 }
+
+
+#[test]
+fun test_init_for_testing() {
+    let admin = @0xAD;
+    let controller = @0x1235;
+    let fee_collector = @0xFEE5;
+    let mut ts = ts::begin(@0x0);
+    ts.next_tx(admin);
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    ts.end();
+}
+


### PR DESCRIPTION
- Enforces correct module initialization using a one-time witness so initialization can only run once.
- Updates test-only init_for_testing to route through canonical initialize(SUI_RAFFLER {}, ...).
- Updates all tests accordingly