### PR TITLE
feat: implement per-user cumulative ticket purchase limits

### DIFF
--- a/sui_raffler/tests/sui_raffler_tests.move
+++ b/sui_raffler/tests/sui_raffler_tests.move
@@ -177,6 +177,93 @@ fun test_raffle_flow() {
     ts.end();
 }
 
+/// Test the get_address_purchase_info view function
+#[test]
+fun test_get_address_purchase_info() {
+    let admin = @0xAD;
+    let creator = @0xBEEF;
+    let organizer = @0x1234;
+    let buyer = @0xB0B;
+    let fee_collector = @0xFEE5;
+    let controller = @0x1235;
+    let start_time = 0;
+    let end_time = 1000;
+    let ticket_price = 100;
+    let max_per_addr = 3;
+
+    // Start with system address for random setup
+    let mut ts = ts::begin(@0x0);
+
+    // Setup randomness
+    random::create_for_testing(ts.ctx());
+    ts.next_tx(@0x0);
+    let mut random_state: Random = ts.take_shared();
+    random_state.update_randomness_state_for_testing(
+        0,
+        x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
+        ts.ctx(),
+    );
+
+    // Initialize module configuration
+    ts.next_tx(admin);
+    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    ts.next_tx(admin);
+    let config = ts.take_shared<sui_raffler::Config>();
+
+    // Create raffle
+    ts.next_tx(creator);
+    mint(creator, 1000, &mut ts);
+    ts.next_tx(creator);
+    sui_raffler::create_raffle(
+        &config,
+        string::utf8(b"Test Raffle"),
+        string::utf8(b"Test Description"),
+        string::utf8(b"https://example.com/image.jpg"),
+        start_time,
+        end_time,
+        ticket_price,
+        max_per_addr,
+        organizer,
+        ts.ctx()
+    );
+    ts.next_tx(creator);
+    let mut raffle = ts.take_shared<sui_raffler::Raffle>();
+
+    // Before any purchase: purchased=0, remaining=max
+    let (p0, r0) = sui_raffler::get_address_purchase_info(&raffle, buyer);
+    assert!(p0 == 0, 1);
+    assert!(r0 == max_per_addr, 1);
+
+    // Buyer buys 2 tickets
+    ts.next_tx(buyer);
+    mint(buyer, ticket_price * 2, &mut ts);
+    let coin: Coin<SUI> = ts.take_from_sender();
+    let clock = clock::create_for_testing(ts.ctx());
+    sui_raffler::buy_tickets(&mut raffle, coin, 2, &clock, ts.ctx());
+
+    // After first purchase: purchased=2, remaining=1
+    let (p1, r1) = sui_raffler::get_address_purchase_info(&raffle, buyer);
+    assert!(p1 == 2, 1);
+    assert!(r1 == 1, 1);
+
+    // Buyer buys 1 more (reaches cap)
+    ts.next_tx(buyer);
+    mint(buyer, ticket_price, &mut ts);
+    let coin2: Coin<SUI> = ts.take_from_sender();
+    sui_raffler::buy_tickets(&mut raffle, coin2, 1, &clock, ts.ctx());
+
+    // After reaching cap: purchased=3, remaining=0
+    let (p2, r2) = sui_raffler::get_address_purchase_info(&raffle, buyer);
+    assert!(p2 == 3, 1);
+    assert!(r2 == 0, 1);
+
+    clock.destroy_for_testing();
+    ts::return_shared(config);
+    ts::return_shared(raffle);
+    ts::return_shared(random_state);
+    ts.end();
+}
+
 /// Test fee collector update functionality
 #[test]
 fun test_fee_collector_update() {


### PR DESCRIPTION
- Add Table<address, u64> to track cumulative purchases per address
- Rename max_tickets_per_purchase to max_tickets_per_address
- Enforce cumulative limit across multiple transactions in buy_tickets
- Add EExceedsPerUserLimit error code for limit violations
- Add get_address_purchase_info view function for frontend integration
- Add comprehensive tests for single-tx and multi-tx limit enforcement
- Add unit test for purchase info view function

BREAKING CHANGE: max_tickets_per_purchase is now max_tickets_per_address and enforces cumulative per-user limits rather than per-transaction limits