### PR TITLE
Implement init pattern and update tests

### DIFF
--- a/sui_raffler/sources/sui_raffler.move
+++ b/sui_raffler/sources/sui_raffler.move
@@ -28,6 +28,7 @@ module sui_raffler::sui_raffler {
     use std::string::{String};
     use sui::types;
     use sui::table::{Self, Table};
+    use sui::test_scenario::ctx;
 
     // OTW - One time witness
     public struct SUI_RAFFLER has drop {}
@@ -141,13 +142,13 @@ module sui_raffler::sui_raffler {
 
     /// Initialize the module with admin, controller, and fee collector addresses
     /// This function can only be called once during module deployment
-    fun initialize(otw: SUI_RAFFLER, admin: address, controller: address, fee_collector: address, ctx: &mut TxContext) {
+    fun init(otw: SUI_RAFFLER, ctx: &mut TxContext) {
         assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
         let config = Config {
             id: object::new(ctx),
-            admin,
-            controller,
-            fee_collector,
+            admin: ctx.sender(),
+            controller: ctx.sender(),
+            fee_collector: ctx.sender(),
             paused: false,
             permissionless: true,
         };
@@ -684,8 +685,8 @@ module sui_raffler::sui_raffler {
     }
     
     #[test_only]
-    public fun init_for_testing(admin: address, controller: address, fee_collector: address, ctx: &mut TxContext){
-        initialize(SUI_RAFFLER {}, admin, controller, fee_collector, ctx);
+    public fun init_for_testing(ctx: &mut TxContext){
+        init(SUI_RAFFLER {},  ctx);
     }
 
 }

--- a/sui_raffler/sources/sui_raffler.move
+++ b/sui_raffler/sources/sui_raffler.move
@@ -28,7 +28,6 @@ module sui_raffler::sui_raffler {
     use std::string::{String};
     use sui::types;
     use sui::table::{Self, Table};
-    use sui::test_scenario::ctx;
 
     // OTW - One time witness
     public struct SUI_RAFFLER has drop {}

--- a/sui_raffler/tests/sui_raffler_return_tests.move
+++ b/sui_raffler/tests/sui_raffler_return_tests.move
@@ -22,8 +22,6 @@ fun setup_raffle_with_two_tickets(
     organizer: address,
     buyer1: address,
     buyer2: address,
-    fee_collector: address,
-    controller: address,
     start_time: u64,
     end_time: u64,
     ticket_price: u64,
@@ -44,7 +42,7 @@ fun setup_raffle_with_two_tickets(
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -94,8 +92,6 @@ fun test_is_in_return_state() {
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -107,8 +103,6 @@ fun test_is_in_return_state() {
         organizer,
         buyer1,
         buyer2,
-        fee_collector,
-        controller,
         start_time,
         end_time,
         ticket_price,
@@ -144,8 +138,6 @@ fun test_release_raffle_insufficient_tickets() {
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -157,8 +149,6 @@ fun test_release_raffle_insufficient_tickets() {
         organizer,
         buyer1,
         buyer2,
-        fee_collector,
-        controller,
         start_time,
         end_time,
         ticket_price,
@@ -169,7 +159,7 @@ fun test_release_raffle_insufficient_tickets() {
     clock.set_for_testing(end_time + 1);
 
     // Try to release raffle
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
     // Clean up
@@ -189,8 +179,6 @@ fun test_claim_prize_insufficient_tickets() {
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -202,8 +190,6 @@ fun test_claim_prize_insufficient_tickets() {
         organizer,
         buyer1,
         buyer2,
-        fee_collector,
-        controller,
         start_time,
         end_time,
         ticket_price,
@@ -232,8 +218,6 @@ fun test_claim_organizer_share_insufficient_tickets() {
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -245,8 +229,6 @@ fun test_claim_organizer_share_insufficient_tickets() {
         organizer,
         buyer1,
         buyer2,
-        fee_collector,
-        controller,
         start_time,
         end_time,
         ticket_price,
@@ -275,8 +257,6 @@ fun test_buy_tickets_after_end() {
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
     let buyer3 = @0xB0B3;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -288,8 +268,6 @@ fun test_buy_tickets_after_end() {
         organizer,
         buyer1,
         buyer2,
-        fee_collector,
-        controller,
         start_time,
         end_time,
         ticket_price,
@@ -321,8 +299,6 @@ fun test_return_tickets() {
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -334,8 +310,6 @@ fun test_return_tickets() {
         organizer,
         buyer1,
         buyer2,
-        fee_collector,
-        controller,
         start_time,
         end_time,
         ticket_price,

--- a/sui_raffler/tests/sui_raffler_security_tests.move
+++ b/sui_raffler/tests/sui_raffler_security_tests.move
@@ -23,11 +23,9 @@ fun test_update_admin_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
     let new_admin = @0xAD2;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -46,11 +44,9 @@ fun test_update_controller_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
     let new_controller = @0x1236;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -69,11 +65,9 @@ fun test_update_fee_collector_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
     let new_fee_collector = @0xFEE6;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -91,11 +85,9 @@ fun test_update_fee_collector_unauthorized() {
 fun test_pause_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -113,12 +105,10 @@ fun test_pause_unauthorized() {
 fun test_pause_raffle_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -154,8 +144,6 @@ fun test_pause_raffle_unauthorized() {
 fun test_release_raffle_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
 
     // Start with system address for random setup
@@ -173,7 +161,7 @@ fun test_release_raffle_unauthorized() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -215,8 +203,6 @@ fun test_release_raffle_unauthorized() {
 fun test_claim_organizer_share_unauthorized() {
     let admin = @0xAD;
     let non_organizer = @0xBEEF;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
 
@@ -235,7 +221,7 @@ fun test_claim_organizer_share_unauthorized() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -264,7 +250,7 @@ fun test_claim_organizer_share_unauthorized() {
     sui_raffler::buy_tickets(&mut raffle, coin, 3, &clock, ts.ctx());
 
     // Create clock and set time after end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     clock.set_for_testing(1001);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
@@ -285,8 +271,6 @@ fun test_claim_organizer_share_unauthorized() {
 #[expected_failure(abort_code = sui_raffler::ENotWinner)]
 fun test_claim_prize_unauthorized() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
@@ -306,7 +290,7 @@ fun test_claim_prize_unauthorized() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -341,7 +325,7 @@ fun test_claim_prize_unauthorized() {
     sui_raffler::buy_tickets(&mut raffle, coin2, 2, &clock, ts.ctx());
 
     // Release raffle after end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     clock.set_for_testing(1001);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
@@ -372,13 +356,11 @@ fun test_claim_prize_unauthorized() {
 #[expected_failure(abort_code = sui_raffler::ERafflePaused)]
 fun test_cannot_buy_tickets_when_paused() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -421,12 +403,10 @@ fun test_cannot_buy_tickets_when_paused() {
 #[expected_failure(abort_code = sui_raffler::EPaused)]
 fun test_cannot_create_raffle_when_contract_paused() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -459,12 +439,10 @@ fun test_cannot_create_raffle_when_contract_paused() {
 fun test_create_raffle_not_permissionless() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -496,13 +474,11 @@ fun test_create_raffle_not_permissionless() {
 #[expected_failure(abort_code = sui_raffler::ERaffleNotActive)]
 fun test_buy_tickets_before_start() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -541,13 +517,11 @@ fun test_buy_tickets_before_start() {
 #[expected_failure(abort_code = sui_raffler::ERaffleNotActive)]
 fun test_buy_tickets_after_end() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -587,8 +561,6 @@ fun test_buy_tickets_after_end() {
 #[expected_failure(abort_code = sui_raffler::EInvalidTicketAmount)]
 fun test_buy_tickets_exceeds_per_purchase_limit() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
     let start_time = 0;
@@ -597,7 +569,7 @@ fun test_buy_tickets_exceeds_per_purchase_limit() {
     let max_tickets_per_address = 3; // enforce small cap
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -636,8 +608,6 @@ fun test_buy_tickets_exceeds_per_purchase_limit() {
 #[expected_failure(abort_code = sui_raffler::EExceedsPerUserLimit)]
 fun test_buy_tickets_two_txs_exceed_cumulative_limit() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
     let start_time = 0;
@@ -646,7 +616,7 @@ fun test_buy_tickets_two_txs_exceed_cumulative_limit() {
     let max_tickets_per_address = 3; // cap per user cumulatively
 
     let mut ts = ts::begin(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -691,8 +661,6 @@ fun test_buy_tickets_two_txs_exceed_cumulative_limit() {
 #[expected_failure(abort_code = sui_raffler::ERaffleNotEnded)]
 fun test_release_raffle_before_end() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
 
     // Start with system address for random setup
@@ -710,7 +678,7 @@ fun test_release_raffle_before_end() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -732,7 +700,7 @@ fun test_release_raffle_before_end() {
     let mut raffle = ts.take_shared<sui_raffler::Raffle>();
 
     // Try to release raffle before end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     let clock = clock::create_for_testing(ts.ctx());
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
@@ -748,8 +716,6 @@ fun test_release_raffle_before_end() {
 #[expected_failure(abort_code = sui_raffler::ERaffleAlreadyReleased)]
 fun test_release_raffle_twice() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
 
@@ -768,7 +734,7 @@ fun test_release_raffle_twice() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -797,12 +763,12 @@ fun test_release_raffle_twice() {
     sui_raffler::buy_tickets(&mut raffle, coin, 3, &clock, ts.ctx());
 
     // Release raffle after end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     clock.set_for_testing(1001);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
     // Try to release raffle again
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
     clock.destroy_for_testing();
@@ -817,8 +783,6 @@ fun test_release_raffle_twice() {
 #[expected_failure(abort_code = sui_raffler::EAlreadyClaimed)]
 fun test_claim_organizer_share_twice() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer = @0xB0B;
 
@@ -837,7 +801,7 @@ fun test_claim_organizer_share_twice() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -866,7 +830,7 @@ fun test_claim_organizer_share_twice() {
     sui_raffler::buy_tickets(&mut raffle, coin, 3, &clock, ts.ctx());
 
     // Release raffle after end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     clock.set_for_testing(1001);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
@@ -890,8 +854,6 @@ fun test_claim_organizer_share_twice() {
 #[test]
 fun test_log_winning_tickets() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
@@ -912,7 +874,7 @@ fun test_log_winning_tickets() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -953,7 +915,7 @@ fun test_log_winning_tickets() {
     sui_raffler::buy_tickets(&mut raffle, coin3, 2, &clock, ts.ctx());
 
     // Release raffle after end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     clock.set_for_testing(1001);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
@@ -982,8 +944,6 @@ fun test_log_winning_tickets() {
 #[test]
 fun test_prize_claiming() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
     let organizer = @0x1234;
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
@@ -1004,7 +964,7 @@ fun test_prize_claiming() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -1045,7 +1005,7 @@ fun test_prize_claiming() {
     sui_raffler::buy_tickets(&mut raffle, coin3, 2, &clock, ts.ctx());
 
     // Release raffle after end time
-    ts.next_tx(controller);
+    ts.next_tx(admin);
     clock.set_for_testing(1001);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 

--- a/sui_raffler/tests/sui_raffler_tests.move
+++ b/sui_raffler/tests/sui_raffler_tests.move
@@ -29,8 +29,6 @@ fun test_raffle_flow() {
     let creator = @0xBEEF;
     let organizer = @0x1234;
     let buyer = @0xB0B;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -51,10 +49,10 @@ fun test_raffle_flow() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
-    assert!(sui_raffler::get_config_fee_collector(&config) == fee_collector, 1);
+    assert!(sui_raffler::get_config_fee_collector(&config) == admin, 1);
 
     // Create raffle
     ts.next_tx(creator);
@@ -95,7 +93,7 @@ fun test_raffle_flow() {
     assert!(price == 100, 1);
     assert!(max_tix == 5, 1);
     assert!(org == organizer, 1);
-    assert!(fee_col == fee_collector, 1);
+    assert!(fee_col == admin, 1);
     assert!(balance == 300, 1);
     assert!(sold == 3, 1);
     assert!(!released, 1);
@@ -117,8 +115,8 @@ fun test_raffle_flow() {
     assert!(!has_winners, 1);
     assert!(vector::is_empty(&winners), 1);
 
-    // Controller releases raffle after end_time
-    ts.next_tx(controller);
+    // Admin releases raffle after end_time
+    ts.next_tx(admin);
     clock.set_for_testing(end_time + 1);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
     assert!(sui_raffler::is_released(&raffle), 1);
@@ -184,8 +182,6 @@ fun test_get_address_purchase_info() {
     let creator = @0xBEEF;
     let organizer = @0x1234;
     let buyer = @0xB0B;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -206,7 +202,7 @@ fun test_get_address_purchase_info() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -268,17 +264,15 @@ fun test_get_address_purchase_info() {
 #[test]
 fun test_fee_collector_update() {
     let admin = @0xAD;
-    let initial_fee_collector = @0xFEE5;
     let new_fee_collector = @0xFEE6;
-    let controller = @0x1235;
 
     let mut ts = ts::begin(admin);
 
     // Initialize module configuration
-    sui_raffler::init_for_testing(admin, controller, initial_fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
-    assert!(sui_raffler::get_config_fee_collector(&config) == initial_fee_collector, 1);
+    assert!(sui_raffler::get_config_fee_collector(&config) == admin, 1);
 
     // Update fee collector as admin
     sui_raffler::update_fee_collector(&mut config, new_fee_collector, ts.ctx());
@@ -295,14 +289,12 @@ fun test_fee_collector_update() {
 fun test_fee_collector_update_unauthorized() {
     let admin = @0xAD;
     let non_admin = @0xBEEF;
-    let initial_fee_collector = @0xFEE5;
     let new_fee_collector = @0xFEE6;
-    let controller = @0x1235;
 
     let mut ts = ts::begin(admin);
 
     // Initialize module configuration
-    sui_raffler::init_for_testing(admin, controller, initial_fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let mut config = ts.take_shared<sui_raffler::Config>();
 
@@ -321,14 +313,12 @@ fun test_fee_collector_update_unauthorized() {
 fun test_invalid_organizer() {
     let admin = @0xAD;
     let creator = @0xBEEF;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let invalid_organizer = @0x0;
 
     let mut ts = ts::begin(admin);
 
     // Initialize module configuration
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -361,8 +351,6 @@ fun test_happy_path_raffle() {
     let buyer1 = @0xB0B;
     let buyer2 = @0xB0B2;
     let buyer3 = @0xB0B3;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -383,10 +371,10 @@ fun test_happy_path_raffle() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
-    assert!(sui_raffler::get_config_fee_collector(&config) == fee_collector, 1);
+    assert!(sui_raffler::get_config_fee_collector(&config) == admin, 1);
 
     // Create raffle
     ts.next_tx(creator);
@@ -481,8 +469,8 @@ fun test_happy_path_raffle() {
     assert!(org_share == 90, 1); // 10% of 900
     assert!(fee == 45, 1); // 5% of 900
 
-    // Controller releases raffle after end_time
-    ts.next_tx(controller);
+    // Admin releases raffle after end_time
+    ts.next_tx(admin);
     clock.set_for_testing(end_time + 1);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
     
@@ -657,8 +645,6 @@ fun test_protocol_fee_auto_collection() {
     let creator = @0xBEEF;
     let organizer = @0x1234;
     let buyer = @0xB0B;
-    let fee_collector = @0xFEE5;
-    let controller = @0x1235;
     let start_time = 0;
     let end_time = 1000;
     let ticket_price = 100;
@@ -679,7 +665,7 @@ fun test_protocol_fee_auto_collection() {
 
     // Initialize module configuration
     ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
     let config = ts.take_shared<sui_raffler::Config>();
 
@@ -716,17 +702,17 @@ fun test_protocol_fee_auto_collection() {
     assert!(total == 500, 1);
     assert!(fee == 25, 1); // 5% of 500 = 25
 
-    // Controller releases raffle after end_time
-    ts.next_tx(controller);
+    // Admin releases raffle after end_time
+    ts.next_tx(admin);
     clock.set_for_testing(end_time + 1);
     sui_raffler::release_raffle(&config, &mut raffle, &random_state, &clock, ts.ctx());
 
     // Verify protocol fees were automatically collected
-    ts.next_tx(fee_collector);
+    ts.next_tx(admin);
     let fee_coin: Coin<SUI> = ts.take_from_sender();
     let fee_amount = coin::value(&fee_coin);
     assert!(fee_amount == 25, 1); // 5% of 500 = 25
-    transfer::public_transfer(fee_coin, fee_collector);
+    transfer::public_transfer(fee_coin, admin);
 
     // Verify raffle state after release
     let (_, _, _, _, _, _, _, _, _, balance, sold, _, total, _, _, _, _, fee) = sui_raffler::get_raffle_info(&raffle);
@@ -747,11 +733,8 @@ fun test_protocol_fee_auto_collection() {
 #[test]
 fun test_init_for_testing() {
     let admin = @0xAD;
-    let controller = @0x1235;
-    let fee_collector = @0xFEE5;
-    let mut ts = ts::begin(@0x0);
-    ts.next_tx(admin);
-    sui_raffler::init_for_testing(admin, controller, fee_collector, ts.ctx());
+    let mut ts = ts::begin(admin);
+    sui_raffler::init_for_testing(ts.ctx());
     ts.end();
 }
 


### PR DESCRIPTION
- Replace initialize function with init function using OTW pattern
- Update init_for_testing to use ctx.sender() for admin/controller/fee_collector
- Remove unused admin/controller/fee_collector parameters from all test functions
- Update all test assertions to use admin address instead of separate fee_collector
- Update controller operations to use admin address in tests
- Clean up unused variables and fix mutability declarations
- All tests now properly reflect the new architecture where admin, controller, and fee_collector are all set to ctx.sender() by default