### PR TITLE
Add Minimum Ticket Price Feature

### DIFF
--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -106,14 +106,6 @@ const quickDurationOptions = [
   { label: "1 week", value: 7 * 24 * 60 * 60 * 1000 },
 ];
 
-// Quick ticket price options
-const quickTicketPriceOptions = [
-  { label: "0.1 SUI", value: "0.1" },
-  { label: "1 SUI", value: "1" },
-  { label: "5 SUI", value: "5" },
-  { label: "10 SUI", value: "10" },
-];
-
 // Quick max tickets options
 const quickMaxTicketsOptions = [
   { label: "1", value: "1" },

--- a/frontend/lib/hooks/useAdminConfig.ts
+++ b/frontend/lib/hooks/useAdminConfig.ts
@@ -9,6 +9,7 @@ export interface AdminConfig {
     paused: boolean;
     permissionless: boolean;
     creationFee: number; // in MIST
+    minTicketPrice: number; // in MIST
 }
 
 export function useAdminConfig() {
@@ -38,6 +39,7 @@ export function useAdminConfig() {
                     paused: fields.paused as boolean,
                     permissionless: fields.permissionless as boolean,
                     creationFee: Number(fields.creation_fee ?? 0),
+                    minTicketPrice: Number(fields.min_ticket_price ?? 0),
                 };
             } catch (error) {
                 console.error('Error fetching admin config:', error);

--- a/frontend/lib/services/adminService.ts
+++ b/frontend/lib/services/adminService.ts
@@ -159,4 +159,40 @@ export class AdminService {
             throw SuiErrorHandler.handleSuiError(error);
         }
     }
+
+    async updateCreationFee(newFee: number): Promise<TransactionResult> {
+        try {
+            const tx = new Transaction();
+
+            tx.moveCall({
+                target: `${PACKAGE_ID}::${MODULE}::update_creation_fee`,
+                arguments: [
+                    tx.object(CONFIG_OBJECT_ID),
+                    tx.pure.u64(newFee),
+                ],
+            });
+
+            return await this.signAndExecute({ transaction: tx });
+        } catch (error) {
+            throw SuiErrorHandler.handleSuiError(error);
+        }
+    }
+
+    async updateMinTicketPrice(newMin: number): Promise<TransactionResult> {
+        try {
+            const tx = new Transaction();
+
+            tx.moveCall({
+                target: `${PACKAGE_ID}::${MODULE}::update_min_ticket_price`,
+                arguments: [
+                    tx.object(CONFIG_OBJECT_ID),
+                    tx.pure.u64(newMin),
+                ],
+            });
+
+            return await this.signAndExecute({ transaction: tx });
+        } catch (error) {
+            throw SuiErrorHandler.handleSuiError(error);
+        }
+    }
 }

--- a/sui_raffler/tests/admin_tests.move
+++ b/sui_raffler/tests/admin_tests.move
@@ -204,7 +204,10 @@ fun test_invalid_organizer() {
     // Initialize module configuration
     sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
-    let config = ts.take_shared<sui_raffler::Config>();
+    let mut config = ts.take_shared<sui_raffler::Config>();
+    // Lower min ticket price for this test context
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 0, ts.ctx());
     let payment_coin = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());
 
     // Try to create raffle with invalid organizer address

--- a/sui_raffler/tests/error_condition_tests.move
+++ b/sui_raffler/tests/error_condition_tests.move
@@ -402,7 +402,10 @@ fun test_burn_tickets_different_raffle() {
     ts.next_tx(admin);
     sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
-    let config = ts.take_shared<sui_raffler::Config>();
+    let mut config = ts.take_shared<sui_raffler::Config>();
+    // Lower min ticket price for this suite branch
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 0, ts.ctx());
     let payment_coin = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());
     let payment_coin2 = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());
 

--- a/sui_raffler/tests/min_ticket_price_tests.move
+++ b/sui_raffler/tests/min_ticket_price_tests.move
@@ -1,0 +1,112 @@
+#[test_only]
+module sui_raffler::min_ticket_price_tests;
+
+use sui_raffler::sui_raffler;
+use sui_raffler::test_helpers;
+use sui::test_scenario as ts;
+use sui::coin;
+use sui::sui::SUI;
+use sui::clock;
+use std::string;
+
+/// Creating a raffle below the configured minimum should fail
+#[test]
+#[expected_failure(abort_code = sui_raffler::EInvalidTicketPrice)]
+fun test_create_raffle_below_min_price_fails() {
+    let admin = @0xAD;
+    let creator = @0xBEEF;
+    let organizer = @0x1234;
+
+    let mut ts = ts::begin(admin);
+    let mut config = test_helpers::init_config_and_get(admin, &mut ts);
+
+    // Set min to 200 (in MIST units of the test domain)
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 200, ts.ctx());
+
+    let payment_coin = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());
+
+    // Try to create raffle with ticket_price = 100 (below min 200)
+    ts.next_tx(creator);
+    sui_raffler::create_raffle(
+        &config,
+        payment_coin,
+        string::utf8(b"Raffle"),
+        string::utf8(b"Desc"),
+        string::utf8(b"https://img"),
+        0,
+        1000,
+        100, // below min
+        5,
+        organizer,
+        ts.ctx()
+    );
+
+    ts::return_shared(config);
+    ts.end();
+}
+
+/// Creating a raffle at or above the minimum should succeed
+#[test]
+fun test_create_raffle_at_min_price_succeeds() {
+    let admin = @0xAD;
+    let creator = @0xBEEF;
+    let organizer = @0x1234;
+    let buyer = @0x9999;
+
+    let mut ts = ts::begin(admin);
+    let mut config = test_helpers::init_config_and_get(admin, &mut ts);
+
+    // Set min to 200
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 200, ts.ctx());
+
+    let payment_coin = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());
+
+    // Create raffle at min price = 200
+    ts.next_tx(creator);
+    sui_raffler::create_raffle(
+        &config,
+        payment_coin,
+        string::utf8(b"Raffle"),
+        string::utf8(b"Desc"),
+        string::utf8(b"https://img"),
+        0,
+        1000,
+        200, // at min
+        5,
+        organizer,
+        ts.ctx()
+    );
+    ts.next_tx(creator);
+    let mut raffle = ts.take_shared<sui_raffler::Raffle>();
+
+    // Ensure getter returns the configured min
+    assert!(sui_raffler::get_min_ticket_price(&config) == 200, 0);
+
+    // Verify raffle was created and is active
+    assert!(sui_raffler::get_tickets_sold(&raffle) == 0, 1);
+    assert!(sui_raffler::get_raffle_balance(&raffle) == 0, 2);
+
+    // Create clock for the raffle
+    let mut clock = clock::create_for_testing(ts.ctx());
+    clock::set_for_testing(&mut clock, 500); // Set to middle of raffle period
+
+    // Buy tickets to verify the raffle works
+    ts.next_tx(buyer);
+    test_helpers::mint(buyer, 400, &mut ts);
+    let coin: coin::Coin<SUI> = ts.take_from_sender();
+    sui_raffler::buy_tickets(&config, &mut raffle, coin, 2, &clock, ts.ctx());
+
+    // Verify tickets were purchased successfully
+    assert!(sui_raffler::get_tickets_sold(&raffle) == 2, 3);
+    assert!(sui_raffler::get_raffle_balance(&raffle) == 400, 4);
+
+    // Clean up - return all objects
+    clock.destroy_for_testing();
+    ts::return_shared(config);
+    ts::return_shared(raffle);
+    ts.end();
+}
+
+

--- a/sui_raffler/tests/raffle_flow_tests.move
+++ b/sui_raffler/tests/raffle_flow_tests.move
@@ -175,8 +175,12 @@ fun test_happy_path_raffle() {
     ts.next_tx(admin);
     sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
-    let config = ts.take_shared<sui_raffler::Config>();
-    // Ensure no creation fee for default tests
+    let mut config = ts.take_shared<sui_raffler::Config>();
+    // Lower min ticket price for this test case
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 0, ts.ctx());
+    
+    // Mint a Coin<SUI> with exactly 2 SUI (2_000_000_000 MIST) for creation fee
     let payment_coin = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());
     assert!(sui_raffler::get_config_fee_collector(&config) == admin, 1);
 

--- a/sui_raffler/tests/test_helpers.move
+++ b/sui_raffler/tests/test_helpers.move
@@ -34,7 +34,11 @@ public fun init_config_and_get(admin: address, ts: &mut ts::Scenario): sui_raffl
     ts.next_tx(admin);
     sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
-    ts.take_shared<sui_raffler::Config>()
+    let mut config = ts.take_shared<sui_raffler::Config>();
+    // Lower min ticket price for unit tests to allow small ticket_price values
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 0, ts.ctx());
+    config
 }
 
 /// Helper: create a basic raffle with shared defaults
@@ -119,7 +123,10 @@ public fun setup_raffle_with_two_tickets(
     ts.next_tx(admin);
     sui_raffler::init_for_testing(ts.ctx());
     ts.next_tx(admin);
-    let config = ts.take_shared<sui_raffler::Config>();
+    let mut config = ts.take_shared<sui_raffler::Config>();
+    // Lower min ticket price for this scenario
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 0, ts.ctx());
     
      // Mint a Coin<SUI> with exactly 2 SUI (2_000_000_000 MIST) for creation fee
     let payment_coin = coin::mint_for_testing<SUI>(2_000_000_000, ts.ctx());

--- a/sui_raffler/tests/view_function_tests.move
+++ b/sui_raffler/tests/view_function_tests.move
@@ -298,3 +298,23 @@ fun test_get_raffle_stats_raffle_ended() {
     ts::return_shared(raffle);
     ts.end();
 }
+
+/// Test the get_min_ticket_price view function
+#[test]
+fun test_get_min_ticket_price() {
+    let admin = @0xAD;
+
+    let mut ts = ts::begin(admin);
+    let mut config = test_helpers::init_config_and_get(admin, &mut ts);
+
+    // Helper lowers min to 0 for unit tests
+    assert!(sui_raffler::get_min_ticket_price(&config) == 0, 0);
+
+    // Update and verify
+    ts.next_tx(admin);
+    sui_raffler::update_min_ticket_price(&mut config, 200, ts.ctx());
+    assert!(sui_raffler::get_min_ticket_price(&config) == 200, 1);
+
+    ts::return_shared(config);
+    ts.end();
+}


### PR DESCRIPTION
# Summary
Enforce a configurable minimum ticket price for raffles. Admins can set and update it; validation runs on raffle creation.
Changes

# Smart Contract

- Add min_ticket_price field to Config (default: 0.001 SUI)
- Add update_min_ticket_price() admin function
- Add get_min_ticket_price() view function
- Enforce minimum in create_raffle() validation

# Tests

- Add unit tests for the minimum price
- Update test helpers and existing tests for backward compatibility

# Frontend

- Add min ticket price to admin config and permissions
- Add admin UI to update the minimum ticket price
- Add validation on the create page
- Show dynamic quick price options starting from the minimum
- Format numbers to show decimals only when needed
- Improve mobile layout

# Value
Prevents very low ticket prices and allows admins to adjust thresholds without code changes.