### PR TITLE
feat: implement Turnstile verification for API routes

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -313,20 +313,7 @@ export default function AdminPage() {
     );
   }
 
-  // Debug logging (remove in production)
-  console.log("Admin permissions check:", {
-    isAdmin,
-    isController,
-    isAdminOrController,
-    config: config
-      ? {
-          admin: config.admin,
-          controller: config.controller,
-          feeCollector: config.feeCollector,
-        }
-      : null,
-    currentAddress: address,
-  });
+  // Admin permissions check
 
   // Additional safety check - ensure we have config data and address
   if (!config || !address) {

--- a/frontend/app/api/v1/ipfs/retrieve/route.ts
+++ b/frontend/app/api/v1/ipfs/retrieve/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cacheService } from '@/lib/services/cache';
+import { validateTurnstileRequest } from '@/lib/utils/turnstileValidator';
 
 export async function GET(request: NextRequest) {
+    // Validate Turnstile token
+    const validationError = await validateTurnstileRequest(request);
+    if (validationError) {
+        return validationError;
+    }
     try {
         const searchParams = request.nextUrl.searchParams;
         const cid = searchParams.get('cid');

--- a/frontend/app/api/v1/ipfs/upload/route.ts
+++ b/frontend/app/api/v1/ipfs/upload/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PinataService } from '@/lib/services/pinata';
+import { validateTurnstileRequest } from '@/lib/utils/turnstileValidator';
 
 export async function POST(request: NextRequest) {
+    // Validate Turnstile token
+    const validationError = await validateTurnstileRequest(request);
+    if (validationError) {
+        return validationError;
+    }
+
     try {
         const formData = await request.formData();
         const file = formData.get('file') as File;

--- a/frontend/app/api/v1/release/[raffleId]/route.ts
+++ b/frontend/app/api/v1/release/[raffleId]/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { PACKAGE_ID, CONFIG_OBJECT_ID, RANDOM_OBJECT_ID } from '@/lib/constants';
+import { validateTurnstileRequest } from '@/lib/utils/turnstileValidator';
 
 interface RaffleFields {
     is_released: boolean;
@@ -16,7 +17,12 @@ interface ClockFields {
 // Initialize Sui client with testnet
 const client = new SuiClient({ url: getFullnodeUrl('testnet') });
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+    // Validate Turnstile token
+    const validationError = await validateTurnstileRequest(request);
+    if (validationError) {
+        return validationError;
+    }
     try {
         // Extract raffleId from the URL
         const url = new URL(request.url);
@@ -53,19 +59,14 @@ export async function POST(request: Request) {
 
         // Get sender address
         const sender = keypair.getPublicKey().toSuiAddress();
-        console.log('Sender address:', sender);
 
         // Get raffle object
-        console.log('Fetching raffle with ID:', raffleId);
-
         const raffle = await client.getObject({
             id: raffleId,
             options: {
                 showContent: true,
             },
         });
-
-        console.log('Raffle response:', JSON.stringify(raffle, null, 2));
 
         if (!raffle.data) {
             console.error('No data in raffle response');
@@ -92,7 +93,6 @@ export async function POST(request: Request) {
         }
 
         const raffleFields = raffle.data.content.fields as unknown as RaffleFields;
-        console.log('Raffle fields:', JSON.stringify(raffleFields, null, 2));
 
         // Check if raffle is already released
         if (raffleFields.is_released) {

--- a/frontend/app/api/v1/turnstile/verify/route.ts
+++ b/frontend/app/api/v1/turnstile/verify/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { TurnstileService } from "@/lib/services/turnstile";
+
+export async function POST(request: NextRequest) {
+    try {
+        const body = await request.json();
+        const token = body.token;
+
+        if (!token || typeof token !== "string") {
+            console.error("Turnstile verify: Missing or invalid token");
+            return NextResponse.json(
+                { success: false, error: "Missing or invalid token" },
+                { status: 400 }
+            );
+        }
+
+        const remoteip = TurnstileService.getClientIP(request);
+        const validation = await TurnstileService.validateToken(token, remoteip);
+
+        if (validation.success) {
+            return NextResponse.json({
+                success: true,
+                hostname: validation.hostname,
+                challenge_ts: validation.challenge_ts,
+            });
+        } else {
+            console.error("Turnstile verify: Validation failed:", validation["error-codes"]);
+            return NextResponse.json(
+                {
+                    success: false,
+                    "error-codes": validation["error-codes"] || ["unknown-error"],
+                },
+                { status: 400 }
+            );
+        }
+    } catch (error) {
+        console.error("Turnstile verify endpoint error:", error);
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        const errorStack = error instanceof Error ? error.stack : undefined;
+        console.error("Error details:", { errorMessage, errorStack });
+
+        return NextResponse.json(
+            {
+                success: false,
+                error: "Internal server error",
+                details: process.env.NODE_ENV === "development" ? errorMessage : undefined
+            },
+            { status: 500 }
+        );
+    }
+}
+

--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -8,6 +8,7 @@ import { useWallet } from "@/lib/context/WalletContext";
 import { useAdminPermissions } from "@/lib/hooks/useAdminPermissions";
 import { useAdminConfig } from "@/lib/hooks/useAdminConfig";
 import { useTransactions } from "@/lib/hooks/useTransactions";
+import { useApiFetch } from "@/lib/hooks/useApiFetch";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
@@ -173,6 +174,7 @@ function ImageUpload({
   const [preview, setPreview] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
+  const apiFetch = useApiFetch();
 
   const uploadFile = useCallback(
     async (file: File) => {
@@ -191,7 +193,7 @@ function ImageUpload({
         const formData = new FormData();
         formData.append("file", file);
 
-        const response = await fetch("/api/v1/ipfs/upload", {
+        const response = await apiFetch("/api/v1/ipfs/upload", {
           method: "POST",
           body: formData,
         });
@@ -216,7 +218,7 @@ function ImageUpload({
         setIsUploading(false);
       }
     },
-    [onImageUpload]
+    [onImageUpload, apiFetch]
   );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -154,6 +154,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        {/* Cloudflare Turnstile Script */}
+        <script
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+          async
+          defer
+        />
         {/* Structured Data for Rich Snippets */}
         <script
           type="application/ld+json"

--- a/frontend/app/raffle/[id]/page.tsx
+++ b/frontend/app/raffle/[id]/page.tsx
@@ -141,7 +141,6 @@ export default function RaffleDetail() {
         raffle.ticket_price
       );
 
-      console.log("Buy tickets result:", result);
       setTransactionDigest(result.digest);
       handleSuccess("Tickets purchased successfully!");
 

--- a/frontend/app/releases/page.tsx
+++ b/frontend/app/releases/page.tsx
@@ -70,11 +70,10 @@ export default function Releases() {
         ],
       });
 
-      const result = await signAndExecute({
+      await signAndExecute({
         transaction: tx,
       });
 
-      console.log("release_raffle result.effects:", result.effects);
       setReleaseSuccess((prev) => ({
         ...prev,
         [raffleId]:

--- a/frontend/components/Providers.tsx
+++ b/frontend/components/Providers.tsx
@@ -7,7 +7,9 @@ import {
 import { getFullnodeUrl } from "@mysten/sui/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { WalletProvider } from "@/lib/context/WalletContext";
+import { TurnstileProvider } from "@/lib/context/TurnstileContext";
 import Header from "./Header";
+import TurnstileModal from "./TurnstileModal";
 
 const queryClient = new QueryClient();
 
@@ -15,15 +17,29 @@ const networks = {
   testnet: { url: getFullnodeUrl("testnet") },
 };
 
+const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || "";
+
 export default function Providers({ children }: { children: React.ReactNode }) {
+  // Debug: log if sitekey is missing
+  if (process.env.NODE_ENV === "development" && !turnstileSiteKey) {
+    console.warn(
+      "NEXT_PUBLIC_TURNSTILE_SITE_KEY is not set. Turnstile protection will not work."
+    );
+  }
+
   return (
     <QueryClientProvider client={queryClient}>
       <SuiClientProvider networks={networks} defaultNetwork="testnet">
         <SuiWalletProvider autoConnect>
-          <WalletProvider>
-            <Header />
-            <main className="pt-16">{children}</main>
-          </WalletProvider>
+          <TurnstileProvider>
+            <WalletProvider>
+              <Header />
+              <main className="pt-16">{children}</main>
+              {turnstileSiteKey && (
+                <TurnstileModal sitekey={turnstileSiteKey} />
+              )}
+            </WalletProvider>
+          </TurnstileProvider>
         </SuiWalletProvider>
       </SuiClientProvider>
     </QueryClientProvider>

--- a/frontend/components/TurnstileModal.tsx
+++ b/frontend/components/TurnstileModal.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTurnstile } from "@/lib/context/TurnstileContext";
+
+declare global {
+  interface Window {
+    turnstile: {
+      render: (
+        container: HTMLElement | string,
+        options: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "error-callback"?: (error: string) => void;
+          "expired-callback"?: () => void;
+          theme?: "light" | "dark" | "auto";
+          size?: "normal" | "compact";
+        }
+      ) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+interface TurnstileModalProps {
+  sitekey: string;
+}
+
+export default function TurnstileModal({ sitekey }: TurnstileModalProps) {
+  const { isVerified, verifyToken, resetVerification, token } = useTurnstile();
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+
+  // Check if Turnstile script is loaded
+  useEffect(() => {
+    const checkScript = () => {
+      if (typeof window !== "undefined" && window.turnstile) {
+        setScriptLoaded(true);
+        return true;
+      }
+      return false;
+    };
+
+    // Check immediately
+    if (checkScript()) return;
+
+    // Poll for script to load
+    let attempts = 0;
+    const maxAttempts = 100; // 10 seconds max wait
+    const interval = setInterval(() => {
+      attempts++;
+      if (checkScript()) {
+        clearInterval(interval);
+      } else if (attempts >= maxAttempts) {
+        console.error("Turnstile script failed to load after 10 seconds");
+        clearInterval(interval);
+      }
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    // Clean up widget when verified
+    if (isVerified && widgetIdRef.current && window.turnstile) {
+      window.turnstile.remove(widgetIdRef.current);
+      widgetIdRef.current = null;
+      return;
+    }
+
+    // Render widget if not verified
+    if (
+      !isVerified &&
+      scriptLoaded &&
+      widgetRef.current &&
+      !widgetIdRef.current
+    ) {
+      // Render Turnstile widget
+      const widgetId = window.turnstile.render(widgetRef.current, {
+        sitekey,
+        theme: "auto",
+        size: "normal",
+        callback: async (token: string) => {
+          try {
+            await verifyToken(token);
+          } catch (error) {
+            console.error("Error in verifyToken callback:", error);
+          }
+        },
+        "error-callback": (error: string) => {
+          console.error("Turnstile error occurred:", error);
+        },
+        "expired-callback": () => {
+          resetVerification();
+        },
+      });
+
+      widgetIdRef.current = widgetId;
+
+      return () => {
+        if (widgetIdRef.current && window.turnstile) {
+          window.turnstile.remove(widgetIdRef.current);
+          widgetIdRef.current = null;
+        }
+      };
+    }
+  }, [isVerified, scriptLoaded, sitekey, verifyToken, resetVerification]);
+
+  // Show loading state while script is loading
+  if (!scriptLoaded) {
+    return (
+      <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 backdrop-blur-sm">
+        <div className="bg-white rounded-lg shadow-2xl p-8 max-w-md w-full mx-4">
+          <div className="text-center mb-6">
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Verify You&apos;re Human
+            </h2>
+            <p className="text-gray-600">Loading verification...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isVerified && token) {
+    return null;
+  }
+
+  // Show modal if not verified or no token
+  return (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 backdrop-blur-sm">
+      <div className="bg-white rounded-lg shadow-2xl p-8 max-w-md w-full mx-4">
+        <div className="text-center mb-6">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Verify You&apos;re Human
+          </h2>
+          <p className="text-gray-600">
+            Please complete the verification to continue
+          </p>
+        </div>
+        <div className="flex justify-center" ref={widgetRef} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -6,10 +6,6 @@ export const FULLNODE_URL = `https://fullnode.${NETWORK}.sui.io:443`;
 export const PACKAGE_ID = process.env.NEXT_PUBLIC_PACKAGE_ID || '0x0';
 export const CONFIG_OBJECT_ID = process.env.NEXT_PUBLIC_CONFIG_OBJECT_ID || '0x0';
 
-console.log("network", NETWORK);
-console.log("packageId", PACKAGE_ID);
-console.log("configObjectId", CONFIG_OBJECT_ID);
-
 export const MODULE = "sui_raffler";
 
 // Shared objects
@@ -33,6 +29,7 @@ export const CREATE_RAFFLE_TARGET = `${PACKAGE_ID}::${MODULE}::create_raffle`;
 export const BUY_TICKETS_TARGET = `${PACKAGE_ID}::${MODULE}::buy_tickets`;
 export const RELEASE_RAFFLE_TARGET = `${PACKAGE_ID}::${MODULE}::release_raffle`;
 export const BURN_TICKETS_TARGET = `${PACKAGE_ID}::${MODULE}::burn_tickets`;
+export const GET_ADDRESS_PURCHASE_INFO_TARGET = `${PACKAGE_ID}::${MODULE}::get_address_purchase_info`;
 
 // Cache configuration
 export const CACHE_MAX_ITEMS = 1000;
@@ -80,6 +77,3 @@ export const QUICK_MAX_TICKETS_OPTIONS = [
     { label: "20", value: "20" },
     { label: "50", value: "50" },
 ];
-
-// Transaction targets for new functions
-export const GET_ADDRESS_PURCHASE_INFO_TARGET = `${PACKAGE_ID}::${MODULE}::get_address_purchase_info`;

--- a/frontend/lib/context/TurnstileContext.tsx
+++ b/frontend/lib/context/TurnstileContext.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+} from "react";
+
+interface TurnstileContextType {
+  isVerified: boolean;
+  verifyToken: (token: string) => Promise<void>;
+  resetVerification: () => void;
+  token: string | null;
+}
+
+const TurnstileContext = createContext<TurnstileContextType | undefined>(
+  undefined
+);
+
+export function TurnstileProvider({ children }: { children: React.ReactNode }) {
+  const [isVerified, setIsVerified] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
+
+  // Check if user is already verified (from sessionStorage)
+  useEffect(() => {
+    const checkStoredToken = () => {
+      try {
+        const storedToken = sessionStorage.getItem("turnstile-token");
+        const storedVerified = sessionStorage.getItem("turnstile-verified");
+        const storedTimestamp = sessionStorage.getItem("turnstile-timestamp");
+
+        if (storedToken && storedVerified === "true" && storedTimestamp) {
+          // Check if token is still valid (tokens expire after 5 minutes = 300000ms)
+          const tokenAge = Date.now() - parseInt(storedTimestamp, 10);
+          if (tokenAge < 300000) {
+            // Token is still valid (less than 5 minutes old)
+            setToken(storedToken);
+            setIsVerified(true);
+          } else {
+            // Token expired, clear it
+            setIsVerified(false);
+            setToken(null);
+            sessionStorage.removeItem("turnstile-token");
+            sessionStorage.removeItem("turnstile-verified");
+            sessionStorage.removeItem("turnstile-timestamp");
+          }
+        } else {
+          // No valid stored token, ensure we start unverified
+          setIsVerified(false);
+          setToken(null);
+        }
+      } catch (error) {
+        console.error("Error checking stored Turnstile token:", error);
+        setIsVerified(false);
+        setToken(null);
+      } finally {
+        setInitialized(true);
+      }
+    };
+
+    // Check immediately
+    checkStoredToken();
+
+    // Check every 30 seconds to catch expired tokens
+    const interval = setInterval(checkStoredToken, 30000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const verifyToken = useCallback(async (token: string) => {
+    try {
+      // Verify token with backend
+      const response = await fetch("/api/v1/turnstile/verify", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ token }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+
+        if (data.success) {
+          setToken(token);
+          setIsVerified(true);
+          // Store in sessionStorage with timestamp (tokens expire after 5 minutes)
+          try {
+            sessionStorage.setItem("turnstile-token", token);
+            sessionStorage.setItem("turnstile-verified", "true");
+            sessionStorage.setItem(
+              "turnstile-timestamp",
+              Date.now().toString()
+            );
+          } catch (storageError) {
+            console.error(
+              "Error storing token in sessionStorage:",
+              storageError
+            );
+          }
+        } else {
+          console.error("Turnstile verification failed:", data["error-codes"]);
+          setIsVerified(false);
+          setToken(null);
+          sessionStorage.removeItem("turnstile-token");
+          sessionStorage.removeItem("turnstile-verified");
+          sessionStorage.removeItem("turnstile-timestamp");
+        }
+      } else {
+        const errorData = await response.json().catch(() => ({}));
+        console.error(
+          "Turnstile verification request failed:",
+          response.status,
+          errorData
+        );
+        setIsVerified(false);
+        setToken(null);
+        sessionStorage.removeItem("turnstile-token");
+        sessionStorage.removeItem("turnstile-verified");
+        sessionStorage.removeItem("turnstile-timestamp");
+      }
+    } catch (error) {
+      console.error("Turnstile verification error:", error);
+      setIsVerified(false);
+      setToken(null);
+    }
+  }, []);
+
+  const resetVerification = useCallback(() => {
+    setIsVerified(false);
+    setToken(null);
+    sessionStorage.removeItem("turnstile-token");
+    sessionStorage.removeItem("turnstile-verified");
+    sessionStorage.removeItem("turnstile-timestamp");
+  }, []);
+
+  // Don't render children until initialized to prevent flash of unverified content
+  if (!initialized) {
+    return null;
+  }
+
+  return (
+    <TurnstileContext.Provider
+      value={{
+        isVerified,
+        verifyToken,
+        resetVerification,
+        token,
+      }}
+    >
+      {children}
+    </TurnstileContext.Provider>
+  );
+}
+
+export function useTurnstile() {
+  const context = useContext(TurnstileContext);
+  if (context === undefined) {
+    throw new Error("useTurnstile must be used within a TurnstileProvider");
+  }
+  return context;
+}

--- a/frontend/lib/hooks/useApiFetch.ts
+++ b/frontend/lib/hooks/useApiFetch.ts
@@ -1,0 +1,65 @@
+import { useCallback } from "react";
+import { useTurnstile } from "@/lib/context/TurnstileContext";
+
+/**
+ * Custom hook that wraps fetch to automatically include Turnstile token
+ * in API requests to protected endpoints
+ */
+export function useApiFetch() {
+    const { token, resetVerification } = useTurnstile();
+
+    const apiFetch = useCallback(
+        async (
+            url: string,
+            options: RequestInit = {}
+        ): Promise<Response> => {
+            const headers = new Headers(options.headers);
+
+            // Add Turnstile token to headers if available and endpoint is protected
+            if (url.startsWith("/api/v1/") && !url.includes("/healthz")) {
+                if (!token) {
+                    console.warn("Turnstile token missing for API request:", url);
+                    // Reset verification to show modal
+                    resetVerification();
+                    return new Response(
+                        JSON.stringify({ error: "Turnstile verification required" }),
+                        {
+                            status: 403,
+                            headers: { "Content-Type": "application/json" },
+                        }
+                    );
+                }
+                headers.set("x-turnstile-token", token);
+            }
+
+            const response = await fetch(url, {
+                ...options,
+                headers,
+            });
+
+            // If we get a 403, the token might have expired
+            if (response.status === 403) {
+                try {
+                    const error = await response.clone().json().catch(() => ({}));
+                    if (
+                        error.error === "Turnstile token required" ||
+                        error.error === "Invalid Turnstile token" ||
+                        error.error === "Turnstile verification required"
+                    ) {
+                        // Token expired or invalid - reset verification to trigger re-verification
+                        resetVerification();
+                    }
+                } catch {
+                    // If parsing fails, just reset anyway
+                    resetVerification();
+                }
+            }
+
+            return response;
+        },
+        [token, resetVerification]
+    );
+
+    return apiFetch;
+}
+

--- a/frontend/lib/services/suiApiService.ts
+++ b/frontend/lib/services/suiApiService.ts
@@ -15,6 +15,7 @@ import {
     UserPurchaseInfo
 } from '../types';
 import { SuiErrorHandler } from '../utils/errorHandler';
+import { fetchWithTurnstile } from '@/lib/utils/fetchWithTurnstile';
 
 export class SuiApiService {
     constructor(private client: SuiClient) { }
@@ -39,7 +40,7 @@ export class SuiApiService {
             // Get image URL from IPFS
             let imageUrl = "";
             try {
-                const imageResponse = await fetch(`/api/v1/ipfs/retrieve?cid=${fields.image}`);
+                const imageResponse = await fetchWithTurnstile(`/api/v1/ipfs/retrieve?cid=${fields.image}`);
                 if (imageResponse.ok) {
                     const blob = await imageResponse.blob();
                     imageUrl = URL.createObjectURL(blob);
@@ -92,7 +93,7 @@ export class SuiApiService {
                                 // Get image URL from IPFS
                                 let imageUrl = "";
                                 try {
-                                    const response = await fetch(`/api/v1/ipfs/retrieve?cid=${fields.image}`);
+                                    const response = await fetchWithTurnstile(`/api/v1/ipfs/retrieve?cid=${fields.image}`);
                                     if (response.ok) {
                                         const blob = await response.blob();
                                         imageUrl = URL.createObjectURL(blob);
@@ -228,8 +229,6 @@ export class SuiApiService {
             // Add timeout and retry logic
             const maxRetries = 2;
             let lastError: unknown;
-
-            console.log('Fetching winners for raffle:', raffleId);
 
             for (let attempt = 0; attempt <= maxRetries; attempt++) {
                 try {

--- a/frontend/lib/services/turnstile.ts
+++ b/frontend/lib/services/turnstile.ts
@@ -1,0 +1,110 @@
+/**
+ * Server-side Turnstile validation service
+ */
+
+interface TurnstileVerifyResponse {
+    success: boolean;
+    "error-codes"?: string[];
+    challenge_ts?: string;
+    hostname?: string;
+}
+
+export class TurnstileService {
+    private static readonly SITEVERIFY_URL =
+        "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+    /**
+     * Validate a Turnstile token with Cloudflare's Siteverify API
+     */
+    static async validateToken(
+        token: string,
+        remoteip?: string
+    ): Promise<TurnstileVerifyResponse> {
+        const secretKey = process.env.TURNSTILE_SECRET_KEY;
+
+        if (!secretKey) {
+            console.error("TURNSTILE_SECRET_KEY is not configured in environment variables");
+            return {
+                success: false,
+                "error-codes": ["missing-input-secret"],
+            };
+        }
+
+        if (!token || typeof token !== "string") {
+            console.error("TurnstileService: Invalid token provided");
+            return {
+                success: false,
+                "error-codes": ["missing-input-response"],
+            };
+        }
+
+        if (token.length > 2048) {
+            console.error("TurnstileService: Token too long:", token.length);
+            return {
+                success: false,
+                "error-codes": ["invalid-input-response"],
+            };
+        }
+
+        try {
+            // Use URLSearchParams instead of FormData for better compatibility
+            const params = new URLSearchParams();
+            params.append("secret", secretKey);
+            params.append("response", token);
+
+            if (remoteip) {
+                params.append("remoteip", remoteip);
+            }
+
+            const response = await fetch(this.SITEVERIFY_URL, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: params.toString(),
+                signal: AbortSignal.timeout(10000), // 10 second timeout
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text().catch(() => "Unknown error");
+                console.error("TurnstileService: Cloudflare API error:", response.status, errorText);
+                return {
+                    success: false,
+                    "error-codes": ["internal-error"],
+                };
+            }
+
+            const result: TurnstileVerifyResponse = await response.json();
+            return result;
+        } catch (error) {
+            console.error("Turnstile validation error:", error);
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+            const errorStack = error instanceof Error ? error.stack : undefined;
+            console.error("TurnstileService error details:", { errorMessage, errorStack });
+
+            return {
+                success: false,
+                "error-codes": ["internal-error"],
+            };
+        }
+    }
+
+    /**
+     * Get client IP address from request headers
+     */
+    static getClientIP(request: Request): string | undefined {
+        // Try Cloudflare header first
+        const cfIP = request.headers.get("CF-Connecting-IP");
+        if (cfIP) return cfIP;
+
+        // Try X-Forwarded-For header
+        const xForwardedFor = request.headers.get("X-Forwarded-For");
+        if (xForwardedFor) {
+            // X-Forwarded-For can contain multiple IPs, take the first one
+            return xForwardedFor.split(",")[0].trim();
+        }
+
+        return undefined;
+    }
+}
+

--- a/frontend/lib/utils/fetchWithTurnstile.ts
+++ b/frontend/lib/utils/fetchWithTurnstile.ts
@@ -1,0 +1,31 @@
+/**
+ * Utility function to add Turnstile token to fetch requests
+ * Can be used in both React components and services
+ */
+export function getTurnstileToken(): string | null {
+    if (typeof window === "undefined") return null;
+    return sessionStorage.getItem("turnstile-token");
+}
+
+/**
+ * Fetch wrapper that automatically adds Turnstile token to protected API requests
+ */
+export async function fetchWithTurnstile(
+    url: string,
+    options: RequestInit = {}
+): Promise<Response> {
+    const token = getTurnstileToken();
+    const headers = new Headers(options.headers);
+
+    // Add Turnstile token to headers if available and endpoint is protected
+    if (token && url.startsWith("/api/v1/") && !url.includes("/healthz")) {
+        headers.set("x-turnstile-token", token);
+    }
+
+    return fetch(url, {
+        ...options,
+        headers,
+    });
+}
+
+

--- a/frontend/lib/utils/turnstileValidator.ts
+++ b/frontend/lib/utils/turnstileValidator.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { TurnstileService } from "@/lib/services/turnstile";
+
+/**
+ * Validates Turnstile token from request headers
+ * Returns null if valid, or a NextResponse with error if invalid
+ * Note: Token should be sent in headers (x-turnstile-token) to avoid consuming request body
+ */
+/**
+ * Get allowed hostnames from environment variable
+ * Format: "domain1.com,domain2.com" or single domain
+ */
+function getAllowedHostnames(): string[] {
+    const allowed = process.env.TURNSTILE_ALLOWED_HOSTNAMES;
+    if (!allowed) return [];
+
+    return allowed.split(",").map(h => h.trim().toLowerCase());
+}
+
+export async function validateTurnstileRequest(
+    request: NextRequest
+): Promise<NextResponse | null> {
+    // Skip validation for healthz and turnstile verify endpoints
+    const url = new URL(request.url);
+    if (url.pathname === "/api/v1/healthz" || url.pathname === "/api/v1/turnstile/verify") {
+        return null;
+    }
+
+    // Get token from headers (frontend should send it in headers)
+    const token =
+        request.headers.get("x-turnstile-token") ||
+        request.headers.get("cf-turnstile-response") ||
+        undefined;
+
+    if (!token) {
+        return NextResponse.json(
+            { error: "Turnstile token required" },
+            { status: 403 }
+        );
+    }
+
+    const remoteip = TurnstileService.getClientIP(request);
+    const validation = await TurnstileService.validateToken(token, remoteip);
+
+    if (!validation.success) {
+        return NextResponse.json(
+            {
+                error: "Invalid Turnstile token",
+                "error-codes": validation["error-codes"] || ["unknown-error"],
+            },
+            { status: 403 }
+        );
+    }
+
+    // Optionally validate hostname matches expected domains
+    const allowedHostnames = getAllowedHostnames();
+    if (allowedHostnames.length > 0 && validation.hostname) {
+        const tokenHostname = validation.hostname.toLowerCase();
+        const isValidHostname = allowedHostnames.some(allowed => {
+            // Allow exact match or subdomain match
+            return tokenHostname === allowed || tokenHostname.endsWith(`.${allowed}`);
+        });
+
+        if (!isValidHostname) {
+            console.warn(`Turnstile hostname mismatch: ${validation.hostname} not in allowed list: ${allowedHostnames.join(", ")}`);
+            // In development, allow any hostname; in production, enforce it
+            if (process.env.NODE_ENV === "production") {
+                return NextResponse.json(
+                    {
+                        error: "Invalid Turnstile hostname",
+                        "error-codes": ["hostname-mismatch"],
+                    },
+                    { status: 403 }
+                );
+            }
+        }
+    }
+
+    return null; // Validation passed
+}
+

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { TurnstileService } from "@/lib/services/turnstile";
+
+export async function middleware(request: NextRequest) {
+    const { pathname } = request.nextUrl;
+
+    // Skip Turnstile validation for healthz and turnstile verify endpoints
+    if (pathname === "/api/v1/healthz" || pathname === "/api/v1/turnstile/verify") {
+        return NextResponse.next();
+    }
+
+    // Only protect API routes under /api/v1 (excluding healthz)
+    if (pathname.startsWith("/api/v1/")) {
+        // Get token from headers
+        const token =
+            request.headers.get("x-turnstile-token") ||
+            request.headers.get("cf-turnstile-response");
+
+        // For GET requests, validate in middleware
+        if (request.method === "GET") {
+            if (!token) {
+                return NextResponse.json(
+                    { error: "Turnstile token required" },
+                    { status: 403 }
+                );
+            }
+
+            const remoteip = TurnstileService.getClientIP(request);
+            const validation = await TurnstileService.validateToken(token, remoteip);
+
+            if (!validation.success) {
+                return NextResponse.json(
+                    {
+                        error: "Invalid Turnstile token",
+                        "error-codes": validation["error-codes"] || ["unknown-error"],
+                    },
+                    { status: 403 }
+                );
+            }
+
+            // Optionally validate hostname in middleware (same logic as in validator)
+            // For simplicity, we'll rely on route handler validation for hostname
+        }
+
+        // For POST/PUT/DELETE requests, validation happens in route handlers
+        // (route handlers call validateTurnstileRequest)
+    }
+
+    return NextResponse.next();
+}
+
+export const config = {
+    matcher: ["/api/v1/:path*"],
+};
+


### PR DESCRIPTION
- Add middleware for Turnstile validation on API routes under /api/v1, excluding healthz and verify endpoints.
- Introduce Turnstile verification in relevant API route handlers for enhanced security.
- Create Turnstile service for server-side validation and client IP retrieval.
- Implement Turnstile context and modal for user verification in the frontend.
- Update components and hooks to integrate Turnstile token handling in API requests.

This commit enhances the security of API endpoints by requiring Turnstile verification, ensuring only validated users can access protected resources.