### PR TITLE
fix: improve DateTimePicker calendar visibility in dark mode

### DIFF
--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -566,6 +566,48 @@ export default function CreateRaffle() {
                             },
                           },
                         },
+                        popper: {
+                          sx: {
+                            "& .MuiPaper-root": {
+                              backgroundColor: isDark
+                                ? "rgb(45, 55, 72) !important"
+                                : "#ffffff",
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersDay-root": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersDay-root:not(.Mui-disabled)": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersDay-root:hover:not(.Mui-disabled)": {
+                              backgroundColor: isDark
+                                ? "rgba(99, 102, 241, 0.3) !important"
+                                : "rgba(0, 0, 0, 0.04)",
+                            },
+                            "& .MuiPickersDay-root.Mui-selected": {
+                              backgroundColor: isDark
+                                ? "rgb(99, 102, 241) !important"
+                                : "#6366f1",
+                              color: "#ffffff !important",
+                            },
+                            "& .MuiPickersCalendarHeader-root": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersCalendarHeader-labelContainer": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersCalendarHeader-switchViewButton": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersArrowSwitcher-button": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiDayCalendar-weekDayLabel": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                          },
+                        },
                       }}
                     />
                   </LocalizationProvider>
@@ -702,6 +744,48 @@ export default function CreateRaffle() {
                               color: isDark ? "#ffffff !important" : "#111827",
                             },
                             "& .MuiPickersInputBase-sectionsContainer *": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                          },
+                        },
+                        popper: {
+                          sx: {
+                            "& .MuiPaper-root": {
+                              backgroundColor: isDark
+                                ? "rgb(45, 55, 72) !important"
+                                : "#ffffff",
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersDay-root": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersDay-root:not(.Mui-disabled)": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersDay-root:hover:not(.Mui-disabled)": {
+                              backgroundColor: isDark
+                                ? "rgba(99, 102, 241, 0.3) !important"
+                                : "rgba(0, 0, 0, 0.04)",
+                            },
+                            "& .MuiPickersDay-root.Mui-selected": {
+                              backgroundColor: isDark
+                                ? "rgb(99, 102, 241) !important"
+                                : "#6366f1",
+                              color: "#ffffff !important",
+                            },
+                            "& .MuiPickersCalendarHeader-root": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersCalendarHeader-labelContainer": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersCalendarHeader-switchViewButton": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiPickersArrowSwitcher-button": {
+                              color: isDark ? "#ffffff !important" : "#111827",
+                            },
+                            "& .MuiDayCalendar-weekDayLabel": {
                               color: isDark ? "#ffffff !important" : "#111827",
                             },
                           },

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -174,3 +174,62 @@ html.dark .MuiPickersInputBase-sectionsContainer * {
   background-color: rgb(99, 102, 241) !important;
   color: rgb(255, 255, 255) !important;
 }
+
+/* Calendar date numbers - ensure visibility */
+.dark .MuiPickersCalendar-root,
+.dark .MuiDayCalendar-root,
+.dark .MuiDayCalendar-weekContainer,
+.dark .MuiDayCalendar-weekDayLabel,
+.dark .MuiPickersDay-root {
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark
+  .MuiPickersDay-root:not(.Mui-disabled):not(.Mui-selected):not(.Mui-selected) {
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark .MuiPickersDay-root:hover:not(.Mui-disabled) {
+  background-color: rgba(99, 102, 241, 0.3) !important;
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark .MuiPickersCalendarHeader-labelContainer,
+.dark .MuiPickersCalendarHeader-label,
+.dark .MuiPickersCalendarHeader-switchViewButton {
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark .MuiPickersArrowSwitcher-button {
+  color: rgb(255, 255, 255) !important;
+}
+
+/* Calendar month/year selection */
+.dark .MuiPickersMonth-root,
+.dark .MuiPickersYear-root,
+.dark .MuiPickersMonth-root:not(.Mui-disabled),
+.dark .MuiPickersYear-root:not(.Mui-disabled) {
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark .MuiPickersMonth-root:hover:not(.Mui-disabled),
+.dark .MuiPickersYear-root:hover:not(.Mui-disabled) {
+  background-color: rgba(99, 102, 241, 0.3) !important;
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark .MuiPickersMonth-root.Mui-selected,
+.dark .MuiPickersYear-root.Mui-selected {
+  background-color: rgb(99, 102, 241) !important;
+  color: rgb(255, 255, 255) !important;
+}
+
+/* Ensure calendar paper background is dark */
+html.dark .MuiPaper-root.MuiPickersPopper-paper,
+html.dark .MuiPickersPopper-paper {
+  background-color: rgb(45, 55, 72) !important;
+}
+
+html.dark .MuiPickersCalendar-root {
+  background-color: rgb(45, 55, 72) !important;
+}


### PR DESCRIPTION
- Add comprehensive CSS rules for calendar date numbers, headers, and navigation
- Add popper slot styling to both Start and End time pickers
- Set dark background (rgb(45, 55, 72)) for calendar popup in dark mode
- Ensure all date numbers, headers, and labels are white in dark mode
- Fix white-on-white text issue that made calendar dates invisible
- Add proper hover and selected states for calendar dates